### PR TITLE
Lower case digest constant in TSIG.java

### DIFF
--- a/org/xbill/DNS/TSIG.java
+++ b/org/xbill/DNS/TSIG.java
@@ -15,7 +15,7 @@ import org.xbill.DNS.utils.*;
 
 public class TSIG {
 
-private static final String HMAC_MD5_STR = "HMAC-MD5.SIG-ALG.REG.INT.";
+private static final String HMAC_MD5_STR = "hmac-md5.sig-alg.reg.int.";
 private static final String HMAC_SHA1_STR = "hmac-sha1.";
 private static final String HMAC_SHA224_STR = "hmac-sha224.";
 private static final String HMAC_SHA256_STR = "hmac-sha256.";


### PR DESCRIPTION
Some old nameservers not changing digest string constant to lower case, causing XFR to fail
