### PR TITLE
Updated ZoneTransferIn to correctly reflect the type of xfr performed

### DIFF
--- a/org/xbill/DNS/ZoneTransferIn.java
+++ b/org/xbill/DNS/ZoneTransferIn.java
@@ -435,7 +435,7 @@ parseRR(Record rec) throws ZoneTransferException {
 			logxfr("got incremental response");
 			state = IXFR_DELSOA;
 		} else {
-			rtype = Type.IXFR;
+			rtype = Type.AXFR;
 			handler.startAXFR();
 			handler.handleRecord(initialsoa);
 			logxfr("got nonincremental response");


### PR DESCRIPTION
rtype should have been set to Type.AXFR, like it was in 2.1.1
